### PR TITLE
Fix downloads + Allow all asset types

### DIFF
--- a/downloader.js
+++ b/downloader.js
@@ -80,7 +80,7 @@ function OnLogin(status, complete) {
 		epic_api.GetOwnedAssets( (success) => {
 			var items = [];
 			Object.keys(global.marketplace_ownedAssets_consolidated).forEach( (key) => {
-				if (global.marketplace_ownedAssets_consolidated[key].developer == "Epic Games") // Epic examples returning 403?
+				if (global.marketplace_ownedAssets_consolidated[key].assetId == "UE") // Skip the editor itself
 					return;
 
 				var isAsset = global.marketplace_ownedAssets_consolidated[key].categories.find ( (cat) => {
@@ -138,7 +138,7 @@ function ShowDownloadAssetsMenu(items, cb) {
 						console.error('Failed to get item manifest. ' + error);
 						return;
 					}
-					var chunkList = global.epic_api.BuildItemChunkListFromManifest(manifest);
+					var chunkList = global.epic_api.BuildItemChunkListFromManifest(buildinfo, manifest);
 					global.epic_api.DownloadItemChunkList(manifest, chunkList, "./download/", (finishedDownloading, chunkDir) => {
 						if (finishedDownloading) {
 							global.epic_api.ExtractAssetFilesFromChunks(manifest, chunkDir, "./download/", (finishedExtracting) => {

--- a/epic_api.js
+++ b/epic_api.js
@@ -589,11 +589,12 @@ function padLeft(nr, n, str){
 	return Array(n-String(nr).length+1).join(str||'0')+nr;
 }
 
-epic_api.prototype.BuildItemChunkListFromManifest = function (manifest) {
+epic_api.prototype.BuildItemChunkListFromManifest = function (buildinfo, manifest) {
 	// Build chunk URL list
 	var chunks = [];
 	//Ref: https://download.epicgames.com/Builds/Rocket/Automated/MagicEffects411/CloudDir/ChunksV3/22/AAC7EF867364B218_CE3BE4D54E7B4ECE663C8EAC2D8929D6.chunk
-	var chunkBaseURL = `http://download.epicgames.com/Builds/Rocket/Automated/${manifest.AppNameString}/CloudDir/ChunksV3/`;
+	var chunk_path = buildinfo.items.CHUNKS['path'];
+	var chunkBaseURL = buildinfo.items.CHUNKS['distribution'] + chunk_path.substring(0, chunk_path.lastIndexOf('/')) + "/ChunksV3/";
 	for ( var chunk in manifest.ChunkHashList )
 	{
 		var hash = ChunkHashToReverseHexEncoding(manifest.ChunkHashList[chunk]);

--- a/epic_api.js
+++ b/epic_api.js
@@ -534,12 +534,11 @@ epic_api.prototype.GetItemBuildInfo = function (catalogItemId, appId, cb) {
 }
 
 // Gets an item's manifest. Callback is of form (error, manifest)
-// Note: This call does not require auth. (lol?)
+// Note: This call does not require auth. (lol?) E: It now does by needing the signature.
 epic_api.prototype.GetItemManifest = function (itemBuildInfo, cb) {
 	var opts = {
-		uri: itemBuildInfo.items.MANIFEST.distribution + itemBuildInfo.items.MANIFEST.path,
+		uri: itemBuildInfo.items.MANIFEST.distribution + itemBuildInfo.items.MANIFEST.path + "?" + itemBuildInfo.items.MANIFEST.signature,
 		headers: { Origin: 'allar_ue4_marketplace_commandline', 'User-Agent': 'game=UELauncher, engine=UE4, build=allar_ue4_marketplace_commandline' },
-		qs: { label: 'Live' },
 	};
 
 	console.log("Getting item manifest.");

--- a/epic_api.js
+++ b/epic_api.js
@@ -3,12 +3,13 @@ var epic_api = function () {};
 
 const rimraf = require('rimraf');
 const mkdirp = require('mkdirp');
-const download = require('download-file');
 const ProgressBar = require('progress');
 const zlib = require('zlib');
 const fs = require('fs');
+var url = require('url')
 
 var slowRequestPool = {maxSockets: 2};
+var downloadPool = { maxSockets: 10 };
 
 global.marketplace = {};
 global.marketplace_ajax = {};
@@ -589,6 +590,57 @@ function padLeft(nr, n, str){
 	return Array(n-String(nr).length+1).join(str||'0')+nr;
 }
 
+function download(file, options, callback) {
+    if (!file) throw("Need a file url to download")
+
+    if (!callback && typeof options === 'function') {
+        callback = options
+    }
+
+    options = typeof options === 'object' ? options : {}
+    options.timeout = options.timeout || 20000
+    options.directory = options.directory ? options.directory : '.'
+    options.retries = options.retries || 3;
+
+    var uri = file.split('/')
+    options.filename = options.filename || uri[uri.length - 1]
+
+    var path = options.directory + "/" + options.filename
+    mkdirp(options.directory, function(err) { 
+        if (err) throw err
+        var file_out = fs.createWriteStream(path);
+        var url_options = {
+            uri: file,
+            pool:  downloadPool,
+            timeout: 60000,
+			headers: { 'User-Agent': 'game=UELauncher, engine=UE4, build=allar_ue4_marketplace_commandline' },
+        };
+        request.get(url_options).on('response', function(response) {
+            if (response.statusCode === 200) {
+                response.pipe(file_out);
+                file_out.on('finish', function() {
+                    file_out.close(function(){
+                        if (callback) 
+                            callback(false, path)
+                    });
+                });
+            }
+            else{
+                if (callback) callback(response.statusCode)
+            }
+        }).on('error', function(err) { // Handle errors
+            if(options.retries > 0){
+                options.retries -= 1;
+                console.log("Retry to download: " + url_options.uri + ". Remaining: " + options.retries);
+                download(file, options, callback);
+                return;
+            }
+            fs.unlink(path);
+            if (cb) cb(err.message);
+        });
+    });
+};
+
 epic_api.prototype.BuildItemChunkListFromManifest = function (buildinfo, manifest) {
 	// Build chunk URL list
 	var chunks = [];
@@ -620,7 +672,7 @@ epic_api.prototype.DownloadItemChunkList = function (manifest, chunkList, downlo
 	console.log("Downloading item chunks.");
 
 	// Perform downloads
-	var bar = new ProgressBar('Progress: (:current / :totalMB) :bar :percent Completed. (ETA: :eta seconds)', {total: chunkList.length});
+	var bar = new ProgressBar('Progress: (:current / :total) :bar :percent Completed. (ETA: :eta seconds)', {total: chunkList.length});
 	var downloadList = downloads; // really stupid code
 	downloadList.forEach( (downloadItem) => {
 		download(downloadItem, { directory: downloadDir, timeout: 50000 }, (err) => {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "cheerio": "^1.0.0-rc.2",
     "console-menu": "^0.1.0",
-    "download-file": "^0.1.5",
     "fs": "0.0.1-security",
     "jquery": "^3.2.1",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
This PR fixes/adds 3 things:

Like mentioned in #2 the download part is currently broken.
This is because the server hosting the manifest now require the `Key-Pair-Id` parameter which is available in the buildInfo.
This is now provided in this PR,

<hr>
The current version does not support multiple different types of asset as part of the chunk url is hardcoded. The chunk url is always (at least in my tests) the one provided in the buildInfo for the manifest file.
This PR allows to list and download everything except the Unreal Editor itself as this leads to UI problems ;)

<hr>
The current version executes one request for each chunk all at once.
This PR replaces the `download` function provided by `download-file` with one using the `request` module which uses a shared pool to limit the concurrent requests.
Additionally it supports retries (albeit kinda crude)

<hr>
If you do not like the `download` changes feel free to pick the commits you like.